### PR TITLE
Optional LH2 patch and Thrust Curves for various solids.

### DIFF
--- a/GameData/Knes/Compatibility/CryoTanks/Knes_LH2.cfg.disabled
+++ b/GameData/Knes/Compatibility/CryoTanks/Knes_LH2.cfg.disabled
@@ -1,0 +1,184 @@
+// Patch for Lh2 engine conversion for Knes
+// Use with CryoTanks to get Hydrolox switcher for LFO tanks.
+// Craft already in flight could end up with double resources.
+//Requires CryoTanks and its dependencies.
+//Author: Zorg
+
+// TO ENABLE CHANGE THE FILE EXTENSION FROM .cfg.disabled to just .cfg
+
+//----------Balance notes--------//
+// For saved craft please make sure to use the B9 switch to select the correct Hydrolox resources in the tanks.
+// The smallest engines use overscaled thrust. Most use 50% of IRL thrust with real world ISP.
+// Typically sea level engines should use 25% scaling. But Vulcain is given 50% since its slightly oversized.
+//------------------------------//
+
+@PART[_Knes_H3_Engine_0625]:NEEDS[CryoTanks]:FOR[Knes_LH2]
+{
+	@MODULE[ModuleEngines*]:HAS[@PROPELLANT[LiquidFuel]]
+	{
+		@maxThrust = 4 //IRL 3.92
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 1.5
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = Oxidizer
+			@ratio = 0.1
+		}
+		!atmosphereCurve {}
+		{
+				key = 0 385
+				key = 1 220
+				key = 6 0.001
+		}
+	}
+}
+
+@PART[_Knes_H2_Engine_09375]:NEEDS[CryoTanks]:FOR[Knes_LH2]
+{
+	@MODULE[ModuleEngines*]:HAS[@PROPELLANT[LiquidFuel]]
+	{
+		@maxThrust = 29 //58.8kn IRL
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 1.5
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = Oxidizer
+			@ratio = 0.1
+		}
+		!atmosphereCurve {}
+		{
+
+		}
+	}
+}
+
+@PART[_Knes_L3S_L3S_HM4_Engine]:NEEDS[CryoTanks]:FOR[Knes_LH2]
+{
+	@MODULE[ModuleEngines*]:HAS[@PROPELLANT[LiquidFuel]]
+	{
+		@maxThrust = 20 //IRL 40 Kn
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 1.5
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = Oxidizer
+			@ratio = 0.1
+		}
+		!atmosphereCurve {}
+		{
+			key = 0 412
+			key = 1 90
+			key = 6 0.001
+		}
+	}
+}
+
+
+@PART[_Knes_L3S_L3S_HM60_Engine]:NEEDS[CryoTanks]:FOR[Knes_LH2]
+{
+	@MODULE[ModuleEngines*]:HAS[@PROPELLANT[LiquidFuel]]
+	{
+		@maxThrust = 400 //IRL 800Kn with growth potential to 1300
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 1.5
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = Oxidizer
+			@ratio = 0.1
+		}
+		!atmosphereCurve {}
+		atmosphereCurve
+		{
+			key = 0 443
+			key = 1 90
+			key = 6 0.001
+		}
+	}
+}
+
+@PART[Knes_Engine_Zebulon]:NEEDS[CryoTanks]:FOR[Knes_LH2]
+{
+	@MODULE[ModuleEngines*]:HAS[@PROPELLANT[LiquidFuel]]
+	{
+		@maxThrust = 31.1 //IRL 62.2
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 1.5
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = Oxidizer
+			@ratio = 0.1
+		}
+		!atmosphereCurve {}
+		atmosphereCurve
+		{
+			key = 0 442
+			key = 1 380
+			key = 6 0.001
+		}
+	}
+}
+
+
+@PART[Knes_Engine_Vulcain]:NEEDS[CryoTanks]:FOR[Knes_LH2]
+{
+	@mass = 1.5
+	@MODULE[ModuleEngines*]:HAS[@PROPELLANT[LiquidFuel]]
+	{
+		@maxThrust = 570 // = 50% scaling to deal with overscaled Ariane 5 core. //427 = 37.5% irl  // //IRL 1140
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = LqdHydrogen
+			@ratio = 1.5
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = Oxidizer
+			@ratio = 0.1
+		}
+		!atmosphereCurve {}
+		atmosphereCurve
+		{
+			key = 0 431
+			key = 1 318
+			key = 6 0.001
+		}
+	}
+}
+
+@PART[Knes_Booster_EAP]:NEEDS[CryoTanks]:FOR[Knes_LH2]
+{
+	@cost = 8500
+	@mass = 10.4
+	@description ^= :$: *105% to 66% thrust curve*.:
+	@MODULE[ModuleEngines*]
+	{
+		@maxThrust = 1587
+		%useThrustCurve = true
+		thrustCurve
+		{
+			key = 0    0.15  0    15
+			key = 0.03 0.66  0.5  0.5
+			key = 1    1    -0.6    0
+		}
+	}
+	@RESOURCE[SolidFuel]
+	{
+		@amount = 6092
+		@maxAmount = 6092
+	}
+}

--- a/GameData/Knes/Compatibility/ThrustCurves/ThrustCurves.cfg
+++ b/GameData/Knes/Compatibility/ThrustCurves/ThrustCurves.cfg
@@ -1,0 +1,33 @@
+//Knes upper stage solids
+// Adds 105% to 30# regressive thrust curve and ability to shut them down.
+@PART[_Knes_Diamant_Booster_P064_0625|_Knes_Diamant2_Booster_Rita2_9375|_Knes_DiamantBP4_Booster_Rita_09375]:AFTER[Knes]
+{
+	@description ^= :$: Can be shut down in flight for more precise orbital insertion. *105% to 50% regressive thrust curve*.:
+  @MODULE[ModuleEngines*]
+  {
+    %allowShutdown = True
+    %allowRestart = False
+    %useThrustCurve = true
+    thrustCurve
+    {
+      key = 0    0.15  0    15
+      key = 0.03 0.50  0.5  0
+      key = 1    1     0.7  0
+    }
+  }
+}
+//Other solids. Adds 105% to 66% regressive thrust curve
+@PART[_Knes_Topaze_Booster_0625,_Knes_Diamant2_Booster_P10_9375,_Knes_Diamant2_Booster_P16_9375]:AFTER[Knes]
+{
+	@description ^= :$: *105% to 66% regressive thrust curve*.:
+  @MODULE[ModuleEngines*]
+  {
+    %useThrustCurve = true
+    thrustCurve
+		{
+			key = 0    0.15  0    15
+			key = 0.03 0.66  0.5  0.5
+			key = 1    1    -0.6    0
+		}
+  }
+}


### PR DESCRIPTION
Adds LH2 configs for all cryogenics engines. The cfg is disabled and needs to be renamed to activate. Requires CryoTanks and its dependencies.

Also added thrust curves to various solid rockets. 105% to 50% curve for upper solids. 

105% to 66% for in line (like Diamant).