### PR TITLE
fix broken atmosphere curves in LH2 patch

### DIFF
--- a/GameData/Knes/Compatibility/CryoTanks/Knes_LH2.cfg.disabled
+++ b/GameData/Knes/Compatibility/CryoTanks/Knes_LH2.cfg.disabled
@@ -62,7 +62,7 @@
 	}
 }
 
-@PART[_Knes_L3S_L3S_HM4_Engine]:NEEDS[CryoTanks]:FOR[Knes_LH2]
+@PART[_Knes_L3S_HM4_Engine]:NEEDS[CryoTanks]:FOR[Knes_LH2]
 {
 	@MODULE[ModuleEngines*]:HAS[@PROPELLANT[LiquidFuel]]
 	{

--- a/GameData/Knes/Compatibility/CryoTanks/Knes_LH2.cfg.disabled
+++ b/GameData/Knes/Compatibility/CryoTanks/Knes_LH2.cfg.disabled
@@ -28,6 +28,7 @@
 			@ratio = 0.1
 		}
 		!atmosphereCurve {}
+		atmosphereCurve
 		{
 				key = 0 385
 				key = 1 220
@@ -52,8 +53,11 @@
 			@ratio = 0.1
 		}
 		!atmosphereCurve {}
+		atmosphereCurve
 		{
-
+		key = 0 400
+		key = 1 100
+		key = 6 0.001
 		}
 	}
 }
@@ -74,6 +78,7 @@
 			@ratio = 0.1
 		}
 		!atmosphereCurve {}
+		atmosphereCurve
 		{
 			key = 0 412
 			key = 1 90


### PR DESCRIPTION
Sorry about that! Some of the atmo curves were broken on the LH2 patch. This fixes them.